### PR TITLE
Run execution script as a login shell

### DIFF
--- a/lib/hive/execution_script.rb
+++ b/lib/hive/execution_script.rb
@@ -52,7 +52,7 @@ module Hive
     def run
       @log.info 'bash.rb - Writing script out to file'
       File.open(@path, 'w') do |f|
-        f.write("#!/bin/bash\n")
+        f.write("#!/bin/bash --login\n")
         f.write("# Set environment\n")
         @env.each do |key, value|
           f.write("export #{key}=#{value}\n")


### PR DESCRIPTION
Some things (eg RVM) do not behave as expected unless the shell is a login shell.
