### PR TITLE
Allow shell workers to claim ports

### DIFF
--- a/lib/hive/worker/shell.rb
+++ b/lib/hive/worker/shell.rb
@@ -6,7 +6,22 @@ module Hive
     class Shell < Worker
       def initialize(options)
         @devicedb_register = false
+
+        @ports = {}
+        if options.has_key?('ports')
+          options['ports'].each do |p|
+            @ports[p] = Hive.data_store.port.assign(Process.pid)
+          end
+        end
+
         super
+      end
+
+      def pre_script(job, file_system, script)
+        @ports.each do |label, port|
+          @log.debug("Add port #{label} (#{port}) as environment variable")
+          script.set_env "HIVE_PORT_#{label.upcase}", port
+        end
       end
     end
   end

--- a/spec/hive/worker/shell_spec.rb
+++ b/spec/hive/worker/shell_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+require 'hive/worker/shell'
+
+module Hive
+  class DataStore
+    def initialize(config)
+    end
+
+    class Port
+      def self.assign(worker)
+        @p += 1
+      end
+    end
+  end
+end
+
+describe Hive::Worker::Shell do
+  describe '#initialize' do
+    it 'registers a port' do
+      Hive.data_store.port.instance_variable_set(:@p, 3999)
+      expect(Hive::Worker::Shell.new('ports' => ['port1']).instance_variable_get(:@ports)).to match({'port1' => 4000})
+    end
+
+    it 'registers two ports' do
+      Hive.data_store.port.instance_variable_set(:@p, 3999)
+      expect(Hive::Worker::Shell.new('ports' => ['port1', 'port2']).instance_variable_get(:@ports)).to match({'port1' => 4000, 'port2' => 4001})
+    end
+  end
+end


### PR DESCRIPTION
Add the following to the settings.yml file:

  controllers:
    shell:
      ports:
        - port1
        - port2

This will assign two ports numbers and add these environment variables to the
execution scripts:
- HIVE_PORT_PORT1
- HIVE_PORT_PORT2
