### PR TITLE
Diagnostic should not be created when not in config

### DIFF
--- a/lib/hive/worker.rb
+++ b/lib/hive/worker.rb
@@ -38,7 +38,7 @@ module Hive
       @queues = @options['queues'].class == Array ? @options['queues'] : []
       
       platform = self.class.to_s.scan(/[^:][^:]*/)[2].downcase
-      @diagnostic_runner = Hive::DiagnosticRunner.new(@options, Hive.config.diagnostics, platform)
+      @diagnostic_runner = Hive::DiagnosticRunner.new(@options, Hive.config.diagnostics, platform) if !Hive.config["diagnostics"].nil?
 
       Hive::Messages.configure do |config|
         config.base_path = Hive.config.network.scheduler
@@ -207,7 +207,7 @@ module Hive
 
     # Diagnostics function to be extended in child class, as required
     def diagnostics
-      @diagnostic_runner.run
+      @diagnostic_runner.run if !@diagnostic_runner.nil?
       status = device_status
       status = set_device_status('idle') if status == 'busy'
       raise DeviceNotReady.new("Current device status: '#{status}'") if status != 'idle'


### PR DESCRIPTION
Should fix issue 21 mentioned in Hive-Runner-Android
