### PR TITLE
Process kill and port clearing

### DIFF
--- a/lib/hive/port_allocator.rb
+++ b/lib/hive/port_allocator.rb
@@ -37,6 +37,8 @@ module Hive
 
     # Relase a single port in the range
     def release_port(p)
+      pid = `lsof -i | grep #{p} | awk '{print $2}'`.strip
+      Process.kill 0, process if !pid.empty?
       @free_ports << p if @allocated_ports.delete(p)
     end
 

--- a/lib/hive/port_allocator.rb
+++ b/lib/hive/port_allocator.rb
@@ -38,7 +38,7 @@ module Hive
     # Relase a single port in the range
     def release_port(p)
       pid = `lsof -i | grep #{p} | awk '{print $2}'`.strip
-      Process.kill 0, process if !pid.empty?
+      Process.kill 0, pid if !pid.empty?
       @free_ports << p if @allocated_ports.delete(p)
     end
 


### PR DESCRIPTION
Observed that many adb ports remain in use while being deleted from the allocated_ports. Many jobs were showing error because used ports are allocated. 

This PR should now hopefully kill the process which are using these ports before being freed. 