### PR TITLE
updated terminal-table version and bumped gem version

### DIFF
--- a/hive-runner.gemspec
+++ b/hive-runner.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'hive-runner'
-  s.version     = '2.1.7'
+  s.version     = '2.1.8'
   s.date        = Time.now.strftime("%Y-%m-%d")
   s.summary     = 'Hive Runner'
   s.description = 'Core component of the Hive CI runner'
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activerecord', '~> 4.2'
   s.add_runtime_dependency 'mono_logger', '~> 1.1'
   s.add_runtime_dependency 'daemons', '~> 1.2'
-  s.add_runtime_dependency 'terminal-table', '~> 1.4'
+  s.add_runtime_dependency 'terminal-table', '~> 1.4', '< 1.7'
   s.add_runtime_dependency 'res', '~> 1.2.5'
   s.add_runtime_dependency 'hive-messages', '~> 1.0.3'
   s.add_runtime_dependency 'devicedb_comms', '~> 0.1'


### PR DESCRIPTION
terminal-table >=1.7 (which has dependency unicode-display-width)has a bug which is causing issue when doing 'hived status'

[Bug](https://github.com/janlelis/unicode-display_width/issues/9)