### PR TITLE
Timeout error message

### DIFF
--- a/lib/hive/execution_script.rb
+++ b/lib/hive/execution_script.rb
@@ -96,10 +96,7 @@ module Hive
           end
         rescue Timeout::Error
           @log.debug("Sub-process keep_running check")
-          if ! ( @keep_running.nil? || @keep_running.call )
-             Process.kill(-9, @pgid)
-             raise TimeoutError.new("Timed out after #{Hive.config.timings.job_timeout} seconds")
-          end
+          Process.kill(-9, @pgid) if ! ( @keep_running.nil? || @keep_running.call )
           
           # TODO Upload in-progress script logs
         end

--- a/lib/hive/execution_script.rb
+++ b/lib/hive/execution_script.rb
@@ -96,8 +96,10 @@ module Hive
           end
         rescue Timeout::Error
           @log.debug("Sub-process keep_running check")
-          Process.kill(-9, @pgid) if ! ( @keep_running.nil? || @keep_running.call )
-          
+          if ! ( @keep_running.nil? || @keep_running.call )
+            Process.kill(-9, @pgid)
+            raise "Script terminated. Check worker logs for more details"
+          end
           # TODO Upload in-progress script logs
         end
       end


### PR DESCRIPTION
1. Changed exception message, because script would not terminate because of only timeout in all cases. 