### PR TITLE
Allow executions script to report errors

### DIFF
--- a/hive-runner.gemspec
+++ b/hive-runner.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'hive-runner'
-  s.version     = '2.1.24'
+  s.version     = '2.1.25'
   s.date        = Time.now.strftime("%Y-%m-%d")
   s.summary     = 'Hive Runner'
   s.description = 'Core component of the Hive CI runner'

--- a/lib/hive/file_system.rb
+++ b/lib/hive/file_system.rb
@@ -11,6 +11,7 @@ module Hive
       make_directory(results_path)
       make_directory(logs_path)
       make_directory(testbed_path)
+      FileUtils.touch(script_errors_file)
     end
 
     def home_path
@@ -23,6 +24,10 @@ module Hive
 
     def logs_path
       @logs_path ||= "#{home_path}/logs"
+    end
+
+    def script_errors_file
+      @script_errors_file ||= File.expand_path('script_errors.txt', logs_path)
     end
 
     def testbed_path

--- a/lib/hive/worker.rb
+++ b/lib/hive/worker.rb
@@ -412,7 +412,7 @@ module Hive
     # Keep the execution script running
     def keep_script_running?
       @log.debug("Keep Running check ")
-      if exceeded_time_limit? || parent_process_dead?
+      if exceeded_time_limit? or parent_process_dead? or File.size(@file_system.script_errors_file) > 0
         return false
       else
         return true


### PR DESCRIPTION
Writing anything to the file `$HIVE_SCRIPT_ERRORS` will result in the test
being reported as an error regardless of the results. This error file is
uploaded to the Scheduler along with other log files.